### PR TITLE
Audit PWA logic and harden Firestore rules

### DIFF
--- a/docs/codebase-review.md
+++ b/docs/codebase-review.md
@@ -1,0 +1,43 @@
+# Codebase Review and Push Notification Findings
+
+## Overview
+This document captures the key issues discovered while reviewing the current codebase and proposes actionable fixes. The push notification pipeline—especially for an iOS 16.4+ Progressive Web App (PWA) using Firebase-backed messaging—receives special attention.
+
+## Follow-up Review
+
+The remediation work in this branch addresses the highest-impact findings from the initial audit:
+
+- **Firestore subscription IDs no longer use `btoa`.** A dedicated helper replaces forward slashes in the endpoint with underscores before persisting, ensuring Firestore accepts the document IDs while still storing the raw endpoint for downstream delivery.【F:src/firebase/messaging.ts†L22-L28】【F:src/firebase/messaging.ts†L65-L85】
+- **`next-pwa` now respects the custom worker.** The build pipeline points `swSrc` to the handcrafted `public/sw.js`, so production bundles keep the push handlers required for iOS PWAs.【F:next.config.ts†L5-L15】【F:public/sw.js†L2-L50】
+- **Blocking alerts were replaced with design-system toasts.** Push enablement and teardown now surface non-blocking toast notifications, aligning with the rest of the UI and improving the installation flow on Safari.【F:src/firebase/messaging.ts†L30-L47】【F:src/firebase/messaging.ts†L87-L122】
+- **Rotation handling now covers the full stack.** The service worker stores the active user’s metadata, resubscribes with the correct VAPID key when Safari rotates endpoints, persists the new subscription through a dedicated API route, and still notifies open clients as a fallback.【F:public/sw.js†L1-L133】【F:src/app/api/push-subscriptions/route.ts†L1-L74】【F:src/firebase/messaging.ts†L1-L229】
+- **Server fan-out normalises Firestore documents.** Both the rotation endpoint and the transaction webhook reuse a shared helper to strip extraneous fields before invoking `webpush.sendNotification`, reducing the risk of future type regressions.【F:src/lib/push-subscriptions.ts†L1-L35】【F:src/app/api/transactions/route.ts†L1-L96】【F:src/app/api/push-subscriptions/route.ts†L1-L74】
+
+## Critical Issues
+
+### 1. Firestore document ID generation breaks subscriptions *(Status: Fixed)*
+`requestNotificationPermission` formerly turned the push endpoint into a Firestore document ID with `btoa(subscription.endpoint)`, producing `/` characters that Safari endpoints almost always include. The updated `buildSubscriptionId` helper strips those slashes, allowing the subscription metadata to be written successfully while preserving the endpoint field for notifications.【F:src/firebase/messaging.ts†L22-L28】【F:src/firebase/messaging.ts†L71-L90】
+
+**Recommendation:** Retain this sanitisation approach or migrate to a hashed identifier if you later need stronger collision guarantees.
+
+### 2. Production builds overwrite the custom service worker *(Status: Fixed)*
+`next-pwa` now receives `swSrc: 'public/sw.js'`, preventing the plugin from replacing the bespoke worker that handles push and notification click events in production builds.【F:next.config.ts†L5-L15】【F:public/sw.js†L2-L50】
+
+**Recommendation:** Keep the `public/sw.js` file version-controlled and validate during CI that the build output still embeds these handlers.
+
+### 3. Firebase Cloud Messaging does not reach iOS Web Push endpoints *(Status: Known Limitation)*
+The backend stores raw Web Push subscriptions and uses `web-push` to fan out messages from a Firebase Admin environment.【F:src/app/api/transactions/route.ts†L17-L126】 This is compatible with browsers that support the VAPID-standard Web Push API. However, Firebase Cloud Messaging (FCM) for Web still does **not** broker notifications to Safari’s `web.push.apple.com` endpoints used by iOS 16+ PWAs. Attempting to send through FCM yields failures because Apple requires APNs credentials or a direct Web Push send.
+
+**Recommendation:** Continue sending through the standards-based `web-push` library (with correct VAPID keys) or integrate APNs by way of Firebase Cloud Functions. Document the limitation so stakeholders do not expect FCM topics or the REST `fcm/send` endpoint to deliver to iOS PWAs until Google adds official support.
+
+## Additional Observations
+
+- ✅ The API route reuses the `PushSubscription` type but never strips `expirationTime`; consider pruning undefined fields before calling `webpush.sendNotification` to avoid future type regressions.【F:src/app/api/transactions/route.ts†L37-L96】
+- ✅ Consider adding a `pushsubscriptionchange` handler inside the service worker so iOS can silently resubscribe when Apple rotates the subscription, preventing stale entries in Firestore.【F:public/sw.js†L91-L133】
+- Client code now surfaces non-blocking toast notifications during permission flows, matching the design system and avoiding disruptive alerts on iOS.【F:src/firebase/messaging.ts†L30-L47】【F:src/firebase/messaging.ts†L95-L122】
+
+## Next Steps
+1. QA the updated subscription identifier logic on real iOS Safari devices and monitor Firestore for duplicate entries.
+2. Add a CI assertion that the built service worker bundle still contains the custom `push` and `notificationclick` handlers.
+3. Keep using standards-based Web Push delivery (or APNs) for iOS PWAs and update documentation to set expectations around FCM coverage.
+4. Monitor logs for the new rotation endpoint/service-worker path to ensure automated resubscriptions succeed in production.

--- a/docs/pwa-logic-audit.md
+++ b/docs/pwa-logic-audit.md
@@ -1,0 +1,23 @@
+# PWA Logic & Rules Audit
+
+## Identified logic conflicts
+
+1. **Transaction edits overwrite the original type and timestamp.** The form code rebuilds the payload with `Type: 'Expense'` and `Date: new Date()` for both creates and updates, so editing an income transaction or changing only the notes silently converts it into a fresh expense logged at “now”.【F:src/components/dashboard/add-transaction-form.tsx†L95-L120】 Consider preserving the original `Type` and `Date` unless the user explicitly changes them.
+2. **Push subscription metadata oscillates between `createdAt` and `updatedAt`.** Client-side persistence rewrites each document without merge, removing the worker-injected `updatedAt` marker and resetting `createdAt` on every sync, while the service worker/API path stores `updatedAt` via a merge write.【F:src/firebase/messaging.ts†L96-L114】【F:src/app/api/push-subscriptions/route.ts†L35-L48】 Switching the client write to a merge (or tracking both fields consistently) would stop the churn.
+3. **The rotation endpoint trusts caller-supplied identities.** `/api/push-subscriptions` accepts an arbitrary `userId` and runs with admin credentials, so any unauthenticated request can create or delete subscriptions for another account if it knows the UID.【F:src/app/api/push-subscriptions/route.ts†L14-L71】 Protect the route by verifying a Firebase Auth token or restricting it to service-worker-signed requests.
+4. **Documentation vs. implementation drift.** The Firestore ruleset comments state that push-subscription documents denormalise a `userId`, yet the actual writes only persist `endpoint` and `keys`, which may cause confusion for future rule changes that rely on the documented shape.【F:firestore.rules†L21-L24】【F:src/firebase/messaging.ts†L96-L114】 Update either the stored schema or the rule documentation to stay aligned.
+
+## Firestore rule hardening
+
+To remove schema ambiguities and prevent malformed writes, the ruleset now:
+
+- Centralises helper predicates for numeric, string, list, and timestamp validation so every collection enforces a consistent shape.【F:firestore.rules†L40-L120】
+- Requires well-formed profile, transaction, budget, and push-subscription payloads on create/update, rejecting missing ownership fields, negative amounts, or malformed key material before they reach the database.【F:firestore.rules†L150-L183】
+
+These constraints still honour the existing ownership model while tightening data integrity; future schema changes should extend the helper functions so the validation surface remains in one place.
+
+## Follow-up suggestions
+
+- Preserve push metadata across rotations by merging client writes (or by storing both `createdAt` and `updatedAt` consistently) to keep audit timelines intact.【F:src/firebase/messaging.ts†L96-L114】【F:src/app/api/push-subscriptions/route.ts†L35-L48】
+- Gate the push-subscription API behind Firebase Auth verification so only the active session can rotate its own endpoints.【F:src/app/api/push-subscriptions/route.ts†L14-L71】
+- Extend the Firestore helpers as new fields are added (for example, whitelisting additional transaction metadata) so validation remains explicit and conflicts stay visible in rules reviews.【F:firestore.rules†L40-L183】

--- a/firestore.rules
+++ b/firestore.rules
@@ -38,6 +38,88 @@ service cloud.firestore {
     }
 
     /**
+     * @description Returns true when the value is either an integer or a float.
+     */
+    function isNumber(value) {
+      return value is int || value is float;
+    }
+
+    /**
+     * @description Returns true when the value is a non-negative number.
+     */
+    function isNonNegativeNumber(value) {
+      return isNumber(value) && value >= 0;
+    }
+
+    /**
+     * @description Ensures the provided value is a non-empty string.
+     */
+    function isNonEmptyString(value) {
+      return value is string && value.size() > 0;
+    }
+
+    /**
+     * @description Allows timestamp literals or server timestamp sentinels.
+     */
+    function isTimestampOrServerTime(value) {
+      return value is timestamp || value == request.time;
+    }
+
+    /**
+     * @description Validates a list that should only contain non-empty strings.
+     */
+    function isStringList(list) {
+      return list is list && list.where(item => item is string && item.size() > 0).size() == list.size();
+    }
+
+    /**
+     * @description Validates the payload written to a user profile document.
+     */
+    function isValidUserProfile(data) {
+      return data.keys().hasOnly(['name', 'categories', 'income', 'savings', 'id']) &&
+             (!('name' in data) || isNonEmptyString(data.name)) &&
+             (!('categories' in data) || isStringList(data.categories)) &&
+             (!('income' in data) || isNonNegativeNumber(data.income)) &&
+             (!('savings' in data) || isNonNegativeNumber(data.savings));
+    }
+
+    /**
+     * @description Validates the payload written to a transaction document.
+     */
+    function isValidTransaction(data, userId) {
+      return data.keys().hasOnly(['Amount', 'Category', 'Notes', 'Type', 'Date', 'userId']) &&
+             isNonNegativeNumber(data.Amount) &&
+             isNonEmptyString(data.Category) &&
+             isNonEmptyString(data.Notes) &&
+             isNonEmptyString(data.Type) &&
+             data.userId == userId &&
+             isTimestampOrServerTime(data.Date);
+    }
+
+    /**
+     * @description Validates the payload written to a budget document.
+     */
+    function isValidBudget(data, budgetId) {
+      return data.keys().hasOnly(['Category', 'MonthlyBudget']) &&
+             (!('Category' in data) || (isNonEmptyString(data.Category) && data.Category == budgetId)) &&
+             (!('MonthlyBudget' in data) || isNonNegativeNumber(data.MonthlyBudget));
+    }
+
+    /**
+     * @description Validates the payload written to a push subscription document.
+     */
+    function isValidPushSubscription(data) {
+      return data.keys().hasOnly(['endpoint', 'keys', 'createdAt', 'updatedAt']) &&
+             isNonEmptyString(data.endpoint) &&
+             data.keys is map &&
+             data.keys.keys().hasOnly(['auth', 'p256dh']) &&
+             isNonEmptyString(data.keys.auth) &&
+             isNonEmptyString(data.keys.p256dh) &&
+             (!('createdAt' in data) || isTimestampOrServerTime(data.createdAt)) &&
+             (!('updatedAt' in data) || isTimestampOrServerTime(data.updatedAt));
+    }
+
+    /**
      * @description Checks if the authenticated user's ID matches the provided userId.
      */
     function isOwner(userId) {
@@ -66,10 +148,11 @@ service cloud.firestore {
      * @principle Enforces document ownership for all operations.
      */
     match /users/{userId} {
-      allow create: if isSignedIn() && isOwner(userId);
+      allow create: if isSignedIn() && isOwner(userId) && isValidUserProfile(request.resource.data);
       allow get: if isSignedIn() && isOwner(userId);
       allow list: if false;
       allow update: if isExistingOwner(userId) &&
+                       isValidUserProfile(request.resource.data) &&
                        // Ensure the id is not being changed in the update
                        (!('id' in request.resource.data) || request.resource.data.id == resource.data.id);
       allow delete: if isExistingOwner(userId);
@@ -91,10 +174,12 @@ service cloud.firestore {
      * @principle Enforces document ownership for all operations.
      */
     match /users/{userId}/transactions/{transactionId} {
-      allow create: if isSignedIn() && isOwner(userId) && request.resource.data.userId == userId;
+      allow create: if isSignedIn() && isOwner(userId) && isValidTransaction(request.resource.data, userId);
       allow get: if isSignedIn() && isOwner(userId);
       allow list: if isSignedIn() && isOwner(userId);
-      allow update: if isExistingOwner(userId) && request.resource.data.userId == resource.data.userId;
+      allow update: if isExistingOwner(userId) &&
+                       isValidTransaction(request.resource.data, userId) &&
+                       request.resource.data.userId == resource.data.userId;
       allow delete: if isExistingOwner(userId);
     }
 
@@ -114,10 +199,10 @@ service cloud.firestore {
      * @principle Enforces document ownership for all operations.
      */
     match /users/{userId}/budgets/{budgetId} {
-      allow create: if isSignedIn() && isOwner(userId);
+      allow create: if isSignedIn() && isOwner(userId) && isValidBudget(request.resource.data, budgetId);
       allow get: if isSignedIn() && isOwner(userId);
       allow list: if isSignedIn() && isOwner(userId);
-      allow update: if isExistingOwner(userId);
+      allow update: if isExistingOwner(userId) && isValidBudget(request.resource.data, budgetId);
       allow delete: if isExistingOwner(userId);
     }
 
@@ -137,10 +222,10 @@ service cloud.firestore {
      * @principle Enforces document ownership for all operations.
      */
     match /users/{userId}/pushSubscriptions/{subscriptionId} {
-      allow create: if isSignedIn() && isOwner(userId);
+      allow create: if isSignedIn() && isOwner(userId) && isValidPushSubscription(request.resource.data);
       allow get: if isSignedIn() && isOwner(userId);
       allow list: if isSignedIn() && isOwner(userId);
-      allow update: if isExistingOwner(userId);
+      allow update: if isExistingOwner(userId) && isValidPushSubscription(request.resource.data);
       allow delete: if isExistingOwner(userId);
     }
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const withPWA = require('next-pwa')({
   skipWaiting: true,
   disable: process.env.NODE_ENV === 'development',
   sw: 'sw.js',
+  swSrc: 'public/sw.js',
   scope: '/',
 });
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,93 @@
 
+const PUSH_METADATA_CACHE = 'push-subscription-metadata';
+const PUSH_METADATA_REQUEST = new Request('/__push_subscription_metadata__');
+
+function urlBase64ToUint8Array(base64String) {
+  const padding = '='.repeat((4 - base64String.length % 4) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+async function storeMetadata(payload) {
+  if (!payload || typeof payload !== 'object') return;
+  const { userId, vapidPublicKey } = payload;
+
+  if (typeof userId !== 'string' || typeof vapidPublicKey !== 'string') {
+    return;
+  }
+
+  const cache = await caches.open(PUSH_METADATA_CACHE);
+  await cache.put(
+    PUSH_METADATA_REQUEST,
+    new Response(JSON.stringify({ userId, vapidPublicKey }), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  );
+}
+
+async function readMetadata() {
+  const cache = await caches.open(PUSH_METADATA_CACHE);
+  const response = await cache.match(PUSH_METADATA_REQUEST);
+
+  if (!response) {
+    return null;
+  }
+
+  try {
+    return await response.json();
+  } catch (error) {
+    console.error('Failed to parse stored push metadata.', error);
+    return null;
+  }
+}
+
+async function clearMetadata() {
+  const cache = await caches.open(PUSH_METADATA_CACHE);
+  await cache.delete(PUSH_METADATA_REQUEST);
+}
+
+async function persistSubscriptionToServer(metadata, subscription, oldEndpoint) {
+  if (!metadata || typeof metadata.userId !== 'string') {
+    throw new Error('Missing user metadata for push subscription persistence.');
+  }
+
+  const body = {
+    userId: metadata.userId,
+    subscription: subscription.toJSON(),
+  };
+
+  if (oldEndpoint) {
+    body.oldEndpoint = oldEndpoint;
+  }
+
+  const response = await fetch('/api/push-subscriptions', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to persist rotated subscription: ${response.status}`);
+  }
+}
+
+async function broadcastSubscriptionChange(payload) {
+  try {
+    const clientsArr = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const client of clientsArr) {
+      client.postMessage({ type: 'PUSH_SUBSCRIPTION_CHANGE', payload });
+    }
+  } catch (error) {
+    console.error('Failed to broadcast push subscription change to clients.', error);
+  }
+}
+
 // --- INSTALL / ACTIVATE ---
 self.addEventListener('install', e => self.skipWaiting());
 self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
@@ -47,4 +136,63 @@ self.addEventListener('notificationclick', e => {
       return clients.openWindow(targetUrl);
     })
   );
+});
+
+// --- SUBSCRIPTION ROTATION ---
+self.addEventListener('pushsubscriptionchange', event => {
+  event.waitUntil(
+    (async () => {
+      const metadata = await readMetadata();
+      const oldEndpoint = event.oldSubscription?.endpoint || null;
+      let refreshedSubscription = event.newSubscription || null;
+      let shouldResubscribe = !refreshedSubscription;
+      let autoPersisted = false;
+
+      if (!refreshedSubscription && metadata?.vapidPublicKey) {
+        try {
+          refreshedSubscription = await self.registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(metadata.vapidPublicKey),
+          });
+          shouldResubscribe = false;
+        } catch (error) {
+          console.error('Failed to automatically resubscribe after pushsubscriptionchange.', error);
+          shouldResubscribe = true;
+        }
+      }
+
+      if (refreshedSubscription && metadata?.userId) {
+        try {
+          await persistSubscriptionToServer(metadata, refreshedSubscription, oldEndpoint);
+          autoPersisted = true;
+        } catch (error) {
+          console.error('Failed to persist rotated subscription from service worker.', error);
+          shouldResubscribe = true;
+        }
+      } else if (refreshedSubscription && !metadata?.userId) {
+        shouldResubscribe = true;
+      }
+
+      await broadcastSubscriptionChange({
+        newSubscription: refreshedSubscription ? refreshedSubscription.toJSON() : null,
+        oldEndpoint,
+        shouldResubscribe,
+        autoPersisted,
+      });
+    })()
+  );
+});
+
+self.addEventListener('message', event => {
+  const { data } = event;
+  if (!data || typeof data !== 'object') return;
+
+  if (data.type === 'STORE_PUSH_METADATA') {
+    event.waitUntil(storeMetadata(data.payload));
+    return;
+  }
+
+  if (data.type === 'CLEAR_PUSH_METADATA') {
+    event.waitUntil(clearMetadata());
+  }
 });

--- a/src/app/api/push-subscriptions/route.ts
+++ b/src/app/api/push-subscriptions/route.ts
@@ -1,0 +1,73 @@
+'use server';
+
+import { NextResponse, type NextRequest } from 'next/server';
+import * as admin from 'firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
+import { buildSubscriptionId, normalizeSubscriptionPayload } from '@/lib/push-subscriptions';
+
+if (admin.apps.length === 0) {
+  admin.initializeApp();
+}
+
+const firestore = admin.firestore();
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { userId, subscription, oldEndpoint } = body ?? {};
+
+    if (typeof userId !== 'string' || !userId.trim()) {
+      return NextResponse.json(
+        { error: 'User ID is required.' },
+        { status: 400 }
+      );
+    }
+
+    const normalized = normalizeSubscriptionPayload(subscription);
+
+    if (!normalized) {
+      return NextResponse.json(
+        { error: 'Invalid subscription payload.' },
+        { status: 400 }
+      );
+    }
+
+    const subscriptionRef = firestore
+      .collection('users')
+      .doc(userId)
+      .collection('pushSubscriptions')
+      .doc(buildSubscriptionId(normalized.endpoint));
+
+    await subscriptionRef.set(
+      {
+        endpoint: normalized.endpoint,
+        keys: normalized.keys,
+        updatedAt: FieldValue.serverTimestamp(),
+      },
+      { merge: true }
+    );
+
+    if (typeof oldEndpoint === 'string' && oldEndpoint && oldEndpoint !== normalized.endpoint) {
+      const oldRef = firestore
+        .collection('users')
+        .doc(userId)
+        .collection('pushSubscriptions')
+        .doc(buildSubscriptionId(oldEndpoint));
+
+      try {
+        await oldRef.delete();
+      } catch (error) {
+        console.warn('Failed to delete stale subscription during rotation.', error);
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Failed to persist push subscription.', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json(
+      { error: 'Failed to persist push subscription.', details: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -6,6 +6,7 @@ import * as admin from 'firebase-admin';
 import { FieldValue } from 'firebase-admin/firestore';
 import webpush from 'web-push';
 import { type PushSubscription } from "web-push";
+import { normalizeSubscriptionPayload } from '@/lib/push-subscriptions';
 
 // Initialize Firebase Admin SDK if not already initialized
 if (admin.apps.length === 0) {
@@ -45,7 +46,27 @@ async function sendPushNotification(userId: string, messageBody: string, url: st
         });
 
         const sendPromises = subscriptionsSnapshot.docs.map(doc => {
-            const subscription = doc.data() as PushSubscription;
+            const rawData = doc.data();
+            const normalized = normalizeSubscriptionPayload(rawData);
+
+            if (!normalized) {
+                console.warn("Skipping malformed push subscription document:", doc.id);
+                return Promise.resolve();
+            }
+
+            const subscription: PushSubscription = {
+                endpoint: normalized.endpoint,
+                keys: normalized.keys,
+            };
+
+            const expirationTime = typeof (rawData as { expirationTime?: unknown }).expirationTime === 'number'
+                ? (rawData as { expirationTime: number }).expirationTime
+                : null;
+
+            if (expirationTime !== null) {
+                subscription.expirationTime = expirationTime;
+            }
+
             return webpush.sendNotification(subscription, payload).catch(error => {
                 // If subscription is expired or invalid, delete it
                 if (error.statusCode === 410 || error.statusCode === 404) {

--- a/src/app/dashboard.tsx
+++ b/src/app/dashboard.tsx
@@ -48,7 +48,13 @@ import { useAuth, useUser, useFirestore, useMemoFirebase, useCollection, useDoc 
 import { doc, collection, setDoc, query, orderBy, limit } from 'firebase/firestore';
 import { signOut, type User } from "firebase/auth";
 import { addDocumentNonBlocking, deleteDocumentNonBlocking, updateDocumentNonBlocking } from "@/firebase/non-blocking-updates";
-import { requestNotificationPermission, unsubscribeFromNotifications, getSubscription } from "@/firebase/messaging";
+import {
+  requestNotificationPermission,
+  unsubscribeFromNotifications,
+  getSubscription,
+  registerSubscriptionChangeListener,
+  syncSubscriptionWithFirestore,
+} from "@/firebase/messaging";
 import { toDate } from "date-fns";
 import { useRouter } from "next/navigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -132,6 +138,12 @@ export function Dashboard() {
     };
     checkSubscription();
   }, []);
+
+  useEffect(() => {
+    if (!isClient || !user || !firestore) return;
+    registerSubscriptionChangeListener(user.uid, firestore);
+    void syncSubscriptionWithFirestore(user.uid, firestore);
+  }, [isClient, user, firestore]);
   
   const handleSetupSave = async (data: { name: string }) => {
     if (!userDocRef || !firestore || !user) return;

--- a/src/firebase/messaging.ts
+++ b/src/firebase/messaging.ts
@@ -1,7 +1,55 @@
 
 'use client';
 
-import { collection, doc, setDoc, deleteDoc, serverTimestamp, Firestore } from "firebase/firestore";
+import { doc, setDoc, deleteDoc, serverTimestamp, Firestore } from "firebase/firestore";
+import { toast } from "@/hooks/use-toast";
+import {
+  buildSubscriptionId,
+  normalizeSubscriptionPayload,
+  type SubscriptionRecord,
+} from "@/lib/push-subscriptions";
+
+type SubscriptionLike = PushSubscription | PushSubscriptionJSON;
+
+let subscriptionChangeListener: ((event: MessageEvent) => void) | null = null;
+let subscriptionListenerUserId: string | null = null;
+
+async function sendMessageToServiceWorker(message: unknown) {
+  const registration = await navigator.serviceWorker.ready;
+  const recipient = registration.active || navigator.serviceWorker.controller;
+
+  if (!recipient) {
+    throw new Error('No active service worker available to receive messages.');
+  }
+
+  recipient.postMessage(message);
+}
+
+async function syncServiceWorkerMetadata(userId: string) {
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+
+  if (!vapidPublicKey) {
+    console.warn('Cannot sync push metadata: VAPID public key is missing.');
+    return;
+  }
+
+  try {
+    await sendMessageToServiceWorker({
+      type: 'STORE_PUSH_METADATA',
+      payload: { userId, vapidPublicKey },
+    });
+  } catch (error) {
+    console.error('Failed to propagate push metadata to the service worker.', error);
+  }
+}
+
+async function clearServiceWorkerMetadata() {
+  try {
+    await sendMessageToServiceWorker({ type: 'CLEAR_PUSH_METADATA' });
+  } catch (error) {
+    console.error('Failed to clear push metadata from the service worker.', error);
+  }
+}
 
 /**
  * Converts a VAPID key from a URL-safe base64 string to a Uint8Array.
@@ -35,11 +83,157 @@ export async function getSubscription(): Promise<PushSubscription | null> {
  * @param userId The ID of the current user.
  * @param firestore The Firestore instance.
  */
+function normalizeSubscription(subscription: SubscriptionLike | null | undefined): SubscriptionRecord | null {
+  if (!subscription) return null;
+
+  const json = typeof (subscription as PushSubscription).toJSON === 'function'
+    ? (subscription as PushSubscription).toJSON()
+    : (subscription as PushSubscriptionJSON);
+
+  return normalizeSubscriptionPayload(json);
+}
+
+async function persistSubscription(userId: string, firestore: Firestore, subscription: SubscriptionLike) {
+  const normalized = normalizeSubscription(subscription);
+
+  if (!normalized) {
+    throw new Error('Received an invalid push subscription payload.');
+  }
+
+  const subscriptionRef = doc(
+    firestore,
+    `users/${userId}/pushSubscriptions`,
+    buildSubscriptionId(normalized.endpoint)
+  );
+
+  await setDoc(subscriptionRef, {
+    endpoint: normalized.endpoint,
+    keys: normalized.keys,
+    createdAt: serverTimestamp(),
+  });
+}
+
+async function removeSubscription(userId: string, firestore: Firestore, endpoint: string | null | undefined) {
+  if (!endpoint) return;
+
+  const subscriptionRef = doc(
+    firestore,
+    `users/${userId}/pushSubscriptions`,
+    buildSubscriptionId(endpoint)
+  );
+
+  await deleteDoc(subscriptionRef);
+}
+
+async function ensureActiveSubscription(
+  userId: string,
+  firestore: Firestore,
+  registration?: ServiceWorkerRegistration
+) {
+  const swRegistration = registration ?? (await navigator.serviceWorker.ready);
+  let subscription = await swRegistration.pushManager.getSubscription();
+
+  const permission = typeof Notification !== 'undefined' ? Notification.permission : 'default';
+
+  if (permission !== 'granted') {
+    if (subscription) {
+      await persistSubscription(userId, firestore, subscription);
+    }
+
+    return subscription;
+  }
+
+  if (!subscription) {
+    subscription = await subscribeWithRegistration(swRegistration, userId, firestore);
+  } else {
+    await persistSubscription(userId, firestore, subscription);
+  }
+
+  return subscription;
+}
+
+async function subscribeWithRegistration(
+  registration: ServiceWorkerRegistration,
+  userId: string,
+  firestore: Firestore
+) {
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  if (!vapidPublicKey) {
+    throw new Error("VAPID public key is not defined in environment variables.");
+  }
+
+  const subscription = await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+  });
+
+  await persistSubscription(userId, firestore, subscription);
+  return subscription;
+}
+
+export function registerSubscriptionChangeListener(userId: string, firestore: Firestore) {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+  if (!userId) return;
+
+  if (subscriptionChangeListener && subscriptionListenerUserId === userId) {
+    return;
+  }
+
+  if (subscriptionChangeListener) {
+    navigator.serviceWorker.removeEventListener('message', subscriptionChangeListener);
+    subscriptionChangeListener = null;
+    subscriptionListenerUserId = null;
+  }
+
+  const handler = async (event: MessageEvent) => {
+    const { data } = event;
+    if (!data || data.type !== 'PUSH_SUBSCRIPTION_CHANGE') return;
+
+    const { newSubscription, oldEndpoint, shouldResubscribe, autoPersisted } = data.payload ?? {};
+    const newEndpoint =
+      newSubscription && typeof newSubscription.endpoint === 'string'
+        ? newSubscription.endpoint
+        : null;
+
+    try {
+      if (oldEndpoint && (!newEndpoint || oldEndpoint !== newEndpoint)) {
+        await removeSubscription(userId, firestore, oldEndpoint);
+      }
+
+      if (newSubscription) {
+        await persistSubscription(userId, firestore, newSubscription as SubscriptionLike);
+        return;
+      }
+
+      if (autoPersisted) {
+        await ensureActiveSubscription(userId, firestore);
+        return;
+      }
+
+      if (shouldResubscribe !== false) {
+        await ensureActiveSubscription(userId, firestore);
+      }
+    } catch (error) {
+      console.error('Failed to synchronize push subscription change.', error);
+    }
+  };
+
+  navigator.serviceWorker.addEventListener('message', handler);
+  subscriptionChangeListener = handler;
+  subscriptionListenerUserId = userId;
+
+  void syncServiceWorkerMetadata(userId);
+}
+
 export async function requestNotificationPermission(userId: string, firestore: Firestore) {
   // Check if Push Notifications are supported
   if (!('Notification' in window) || !('serviceWorker' in navigator) || !('PushManager' in window)) {
     console.warn("Push notifications are not supported in this browser.");
-    alert("Push notifications are not supported on this device or browser.");
+    toast({
+      variant: "destructive",
+      title: "Notifications unsupported",
+      description: "This browser does not support push notifications.",
+    });
     return;
   }
   
@@ -48,46 +242,34 @@ export async function requestNotificationPermission(userId: string, firestore: F
     await navigator.serviceWorker.register('/sw.js');
     console.log('Service Worker registered.');
 
-    // Await the service worker to be ready and active. This is crucial for iOS.
-    const swRegistration = await navigator.serviceWorker.ready;
-    console.log('Service Worker is ready and active:', swRegistration.active);
-
     const permission = await Notification.requestPermission();
     if (permission !== "granted") {
       throw new Error("Push notification permission not granted.");
     }
     console.log('Notification permission granted.');
 
-    const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
-    if (!vapidPublicKey) {
-      throw new Error("VAPID public key is not defined in environment variables.");
-    }
-    console.log('VAPID key found.');
+    // Await the service worker to be ready and active. This is crucial for iOS.
+    const swRegistration = await navigator.serviceWorker.ready;
+    console.log('Service Worker is ready and active:', swRegistration.active);
 
-    const subscription = await swRegistration.pushManager.subscribe({
-      userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(vapidPublicKey),
+    registerSubscriptionChangeListener(userId, firestore);
+    await syncServiceWorkerMetadata(userId);
+
+    const subscription = await ensureActiveSubscription(userId, firestore, swRegistration);
+
+    console.log("Push subscription synchronized:", subscription);
+    toast({
+      title: "Notifications enabled",
+      description: "You'll receive alerts on this device.",
     });
-
-    console.log("Push subscription successful:", subscription);
-
-    // Use a stable identifier for the document ID. The endpoint is a good candidate.
-    // Use btoa to create a filesystem-safe ID from the endpoint URL.
-    const subscriptionId = btoa(subscription.endpoint);
-    const subscriptionRef = doc(firestore, `users/${userId}/pushSubscriptions`, subscriptionId);
-    
-    await setDoc(subscriptionRef, {
-      endpoint: subscription.endpoint,
-      keys: subscription.toJSON().keys,
-      createdAt: serverTimestamp(),
-    });
-
-    console.log("Push subscription saved to Firestore.");
-    alert("Push notifications have been enabled!");
 
   } catch (error) {
     console.error("An error occurred during push notification setup:", error);
-    alert(`Failed to enable push notifications: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    toast({
+      variant: "destructive",
+      title: "Failed to enable notifications",
+      description: error instanceof Error ? error.message : "Unknown error",
+    });
     // Re-throw the error so the calling component can handle UI state if needed
     throw error;
   }
@@ -103,10 +285,11 @@ export async function unsubscribeFromNotifications(userId: string, firestore: Fi
     const subscription = await getSubscription();
     if (!subscription) {
       console.log("No active subscription to unsubscribe from.");
+      await clearServiceWorkerMetadata();
       return;
     }
 
-    const subscriptionId = btoa(subscription.endpoint);
+    const subscriptionId = buildSubscriptionId(subscription.endpoint);
     const subscriptionRef = doc(firestore, `users/${userId}/pushSubscriptions`, subscriptionId);
 
     // Unsubscribe the user first
@@ -116,15 +299,35 @@ export async function unsubscribeFromNotifications(userId: string, firestore: Fi
       // If successful, remove from Firestore
       await deleteDoc(subscriptionRef);
       console.log("Successfully removed subscription from Firestore.");
-      alert("Push notifications have been disabled.");
+      await clearServiceWorkerMetadata();
+      toast({
+        title: "Notifications disabled",
+        description: "You will no longer receive alerts on this device.",
+      });
     } else {
       console.error("Failed to unsubscribe.");
       throw new Error("The unsubscribe operation failed.");
     }
   } catch (error) {
     console.error("Error unsubscribing from push notifications:", error);
-    alert(`Failed to disable push notifications: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    toast({
+      variant: "destructive",
+      title: "Failed to disable notifications",
+      description: error instanceof Error ? error.message : "Unknown error",
+    });
     // Re-throw so the UI can revert its state
     throw error;
+  }
+}
+
+export async function syncSubscriptionWithFirestore(userId: string, firestore: Firestore) {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+  if (!userId) return;
+
+  try {
+    await ensureActiveSubscription(userId, firestore);
+    await syncServiceWorkerMetadata(userId);
+  } catch (error) {
+    console.error('Failed to synchronize push subscription with Firestore on load.', error);
   }
 }

--- a/src/lib/push-subscriptions.ts
+++ b/src/lib/push-subscriptions.ts
@@ -1,0 +1,40 @@
+export interface SubscriptionKeys {
+  auth: string;
+  p256dh: string;
+}
+
+export interface SubscriptionRecord {
+  endpoint: string;
+  keys: SubscriptionKeys;
+}
+
+export function buildSubscriptionId(endpoint: string): string {
+  return endpoint.replace(/\//g, '_');
+}
+
+export function normalizeSubscriptionPayload(payload: unknown): SubscriptionRecord | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const endpoint = typeof (payload as { endpoint?: unknown }).endpoint === 'string'
+    ? (payload as { endpoint: string }).endpoint
+    : null;
+
+  const keysRaw = (payload as { keys?: unknown }).keys;
+  const keys = keysRaw && typeof keysRaw === 'object'
+    ? keysRaw as Record<string, unknown>
+    : null;
+
+  const auth = keys && typeof keys.auth === 'string' ? keys.auth : null;
+  const p256dh = keys && typeof keys.p256dh === 'string' ? keys.p256dh : null;
+
+  if (!endpoint || !auth || !p256dh) {
+    return null;
+  }
+
+  return {
+    endpoint,
+    keys: { auth, p256dh },
+  };
+}


### PR DESCRIPTION
## Summary
- add a PWA logic audit document capturing outstanding push-notification and transaction conflicts
- tighten Firestore security rules with shared validators for profiles, transactions, budgets, and push subscriptions

## Testing
- not run (lint command prompts for interactive configuration)

------
https://chatgpt.com/codex/tasks/task_e_68e3ac2da364832f8ad770fec6c57a2f